### PR TITLE
Log full backup process output

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,7 +73,7 @@ class walg::config {
   }
 
   cron { 'full-backup':
-    command     => "/usr/local/bin/cron-full-backup.sh /usr/local/bin/exporter.env ${walg::retention}",
+    command     => "/usr/local/bin/cron-full-backup.sh /usr/local/bin/exporter.env ${walg::retention} | logger -t walg-fullbackup",
     environment => 'PATH=/usr/local/bin:/usr/bin:/bin',
     user        => 'root',
     hour        => 2,

--- a/templates/cron-full-backup.sh.epp
+++ b/templates/cron-full-backup.sh.epp
@@ -35,7 +35,7 @@ echo 'Starting full backup at $(date)'
 
 # Run basebackup
 export PGHOST=/var/run/postgresql
-sudo -E -u postgres wal-g backup-push $PGDATA
+sudo -E -u postgres wal-g backup-push $PGDATA 2>&1
 
 # Compute target date, retention in days can have decimal part: 14.9
 RETENTION_SECONDS=$(echo $RETENTION_DAYS | awk '{printf "%d",3600*24*$1}')
@@ -89,7 +89,7 @@ if [ -n "$LAST_BACKUP_TO_DELETE" ]; then
     echo "Something went wrong, it seems that this script try to delete all backups. Aborting"
     exit 3
   fi
-  wal-g delete --confirm before FIND_FULL $LAST_BACKUP_TO_DELETE
+  wal-g delete --confirm before FIND_FULL $LAST_BACKUP_TO_DELETE 2>&1
 
 else
   echo "No backup to delete"

--- a/templates/cron-full-backup.sh.epp
+++ b/templates/cron-full-backup.sh.epp
@@ -31,6 +31,8 @@ if [[ $IS_SLAVE != 'f' ]]; then
  exit 0
 fi
 
+echo 'Starting full backup at $(date)'
+
 # Run basebackup
 export PGHOST=/var/run/postgresql
 sudo -E -u postgres wal-g backup-push $PGDATA


### PR DESCRIPTION
Allow backup error diagnosis

We also have to redirect the output to stdout as wal-g does not log anything to stdout
This PR may fix this :
https://github.com/wal-g/wal-g/pull/752