### PR TITLE
Add backup prefix. 

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,8 @@ class walg::config {
   file { '/usr/local/bin/archive_command.sh':
     content => epp('walg/archive_command.sh.epp',
       {
-        'backup_fuse' => $walg::backup_fuse,
+        'backup_fuse'   => $walg::backup_fuse,
+        'backup_prefix' => $walg::backup_prefix,
       }
     ),
     mode    => '0755',
@@ -82,7 +83,7 @@ class walg::config {
 
   if $walg::backup_fuse {
     cron { 'backup-fuse':
-      command     => "/usr/local/bin/backup-fuse.sh",
+      command     => '/usr/local/bin/backup-fuse.sh',
       environment => 'PATH=/usr/local/bin:/usr/bin:/bin',
       user        => 'postgres',
       minute      => '*/5',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class walg (
   Boolean              $prometheus_exporter = false,
   Boolean              $backup_fuse = false,
   Integer              $backup_fuse_threshold_gbytes = 10,
+  String               $backup_prefix = '',
 ) {
   class { 'walg::install': }
   -> class { 'walg::config': }

--- a/templates/archive_command.sh.epp
+++ b/templates/archive_command.sh.epp
@@ -13,8 +13,8 @@ export WALG_GPG_KEY_ID
 if [ -f /tmp/failed_pg_archive ]; then
   exit 0
 else
-  exec wal-g wal-push $2
+  exec <%= $backup_prefix %> wal-g wal-push $2
 fi
 <% } else { -%>
-exec wal-g wal-push $2
+exec <%= $backup_prefix %> wal-g wal-push $2
 <% } -%>


### PR DESCRIPTION
    Add backup prefix.
    This can be usefull if you want to timeoute the command and salvage the database.
