### PR TITLE
feat: Allows postgres to restore by itself

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,9 +86,11 @@ class walg::config {
     'archive_mode':
       value => 'on',
       ;
-
     'archive_command':
       value => '/usr/local/bin/archive_command.sh /usr/local/bin/exporter.env %p',
+      ;
+    'restore_command':
+      value => '/usr/local/bin/wal-g.sh wal-fetch %f %p',
       ;
   }
 


### PR DESCRIPTION
Adding the possibility for postgres to download and restore its backups all by itself.

Signed-off-by: Julien Godin <julien.godin@camptocamp.com>